### PR TITLE
로그인 로직 구현 / 이미지패스 서비스 리팩토링

### DIFF
--- a/PuppyBox/Models/CoreData/CoreDataManager.swift
+++ b/PuppyBox/Models/CoreData/CoreDataManager.swift
@@ -93,17 +93,18 @@ final class CoreDataManager {
         UserDefaults.standard.removeObject(forKey: "isBasicAccountExist")
         print(" UserDefaults 상태 초기화 완료")
     }
-    
+
     // 비밀번호 획득 함수
     func loginVerification(userId: String, password: String) -> Bool {
         let fetchRequest: NSFetchRequest<Account> = Account.fetchRequest()
-        fetchRequest.predicate = NSPredicate(format: "userId == %@", userId)
-        fetchRequest.fetchLimit = 1
-        
-        guard let account = (try? context.fetch(fetchRequest))?.first else {
+        fetchRequest.predicate = NSPredicate(format: "userId == %@", userId) // 유저 id와 일치하는 데이터 검색
+        fetchRequest.fetchLimit = 1 // 1건만 (성능향상)
+
+        guard let account = (try? context.fetch(fetchRequest))?.first else { // 일치하는 데이터가 없을 경우 false
             return false
         }
-        
+
+        // 입력한 패스워드와 일치하면 true 다를경우 false
         return account.password == password ? true : false
     }
 }

--- a/PuppyBox/Models/CoreData/CoreDataManager.swift
+++ b/PuppyBox/Models/CoreData/CoreDataManager.swift
@@ -93,4 +93,17 @@ final class CoreDataManager {
         UserDefaults.standard.removeObject(forKey: "isBasicAccountExist")
         print(" UserDefaults 상태 초기화 완료")
     }
+    
+    // 비밀번호 획득 함수
+    func loginVerification(userId: String, password: String) -> Bool {
+        let fetchRequest: NSFetchRequest<Account> = Account.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "userId == %@", userId)
+        fetchRequest.fetchLimit = 1
+        
+        guard let account = (try? context.fetch(fetchRequest))?.first else {
+            return false
+        }
+        
+        return account.password == password ? true : false
+    }
 }

--- a/PuppyBox/Models/CoreData/CoreDataManager.swift
+++ b/PuppyBox/Models/CoreData/CoreDataManager.swift
@@ -90,7 +90,7 @@ final class CoreDataManager {
         }
 
         // UserDefaults 키 초기화
-        UserDefaults.standard.removeObject(forKey: "isBasicAccountExist")
+        UserSetting.isBasicAccountExist = false
         print(" UserDefaults 상태 초기화 완료")
     }
 

--- a/PuppyBox/Models/ImageSize.swift
+++ b/PuppyBox/Models/ImageSize.swift
@@ -7,4 +7,8 @@ enum ImageSize: String {
     case w500
     case w780
     case original
+    
+    var description: String {
+        return rawValue
+    }
 }

--- a/PuppyBox/Models/ImageSize.swift
+++ b/PuppyBox/Models/ImageSize.swift
@@ -7,7 +7,7 @@ enum ImageSize: String {
     case w500
     case w780
     case original
-    
+
     var description: String {
         return rawValue
     }

--- a/PuppyBox/Models/TestData/UserDummyData.swift
+++ b/PuppyBox/Models/TestData/UserDummyData.swift
@@ -4,4 +4,3 @@
 //
 //  Created by Yoon on 7/16/25.
 //
-

--- a/PuppyBox/Models/UserSetting.swift
+++ b/PuppyBox/Models/UserSetting.swift
@@ -1,0 +1,53 @@
+
+import Foundation
+
+// UserDefault의 다른 값을 하나로 관리하기 위해 @propertyWrapper 사용
+@propertyWrapper
+struct UserDefault<T> { // Wrapper로 쌀 내용
+    let key: String
+    let defaultValue: T
+    let userDefaults: UserDefaults
+
+    init(key: String, defaultValue: T, userDefaults: UserDefaults = UserDefaults.standard) {
+        self.key = key
+        self.defaultValue = defaultValue
+        self.userDefaults = userDefaults
+    }
+
+    var wrappedValue: T {
+        get { // 유저디폴트 값 획득
+            userDefaults.object(forKey: key) as? T ?? defaultValue
+        }
+        set { // 유저디폴트 값 할당
+            userDefaults.set(newValue, forKey: key)
+        }
+    }
+}
+
+// 유저 디폴트 키값을 String 형태로 저장
+enum UDKey {
+    static let isBasicAccountExist = "isBasicAccountExist" // 첫 로그인 판별
+    static let userId = "userId" // 유저 아이디
+    static let password = "password" // 유저 패스워드
+    static let isLogined = "isLogined" // 로그인 했었는지 여부
+}
+
+/*
+ UserDefault 사용할 때 쓸 변수
+ 사용법
+ get : UserSetting.userID
+ set : UserSEtting.userId = "userId"
+ */
+enum UserSetting {
+    @UserDefault(key: UDKey.isBasicAccountExist, defaultValue: false)
+    static var isBasicAccountExist: Bool
+
+    @UserDefault(key: UDKey.userId, defaultValue: "")
+    static var userId: String
+
+    @UserDefault(key: UDKey.password, defaultValue: "")
+    static var password: String
+
+    @UserDefault(key: UDKey.isLogined, defaultValue: false)
+    static var isLogined: Bool
+}

--- a/PuppyBox/Scenes/Login/LoginViewController.swift
+++ b/PuppyBox/Scenes/Login/LoginViewController.swift
@@ -9,7 +9,7 @@ final class LoginViewController: UIViewController {
 
     private let logoOriginSize: CGFloat = 131 / 512 // 비율용 로고 원본 사이즈
     private let logoWidth: CGFloat = 150 // 로고 너비 설정상수
-
+  
     // MARK: - UI Components
 
     // 로고 이미지
@@ -46,7 +46,7 @@ final class LoginViewController: UIViewController {
     }
 
     // 비밀번호 입력 란
-    private let passwordLabelTextField = UITextField().then {
+    private let passwordTextField = UITextField().then {
         $0.borderStyle = .roundedRect
         $0.isSecureTextEntry = true
         $0.placeholder = "비밀번호를 입력해주세요."
@@ -57,6 +57,7 @@ final class LoginViewController: UIViewController {
         $0.text = "비밀번호를 잘못 입력했습니다."
         $0.font = .systemFont(ofSize: 12, weight: .regular)
         $0.textColor = .red
+        $0.isHidden = true
     }
 
     // 회원가입 글자 좌측
@@ -102,6 +103,16 @@ final class LoginViewController: UIViewController {
 
         configureUI() // UI 생성
         DummyService.createBasicAccount() // 더미생성 함수
+        
+        loginButton.addAction(UIAction { [weak self] _ in
+           guard let self,
+                 let userId = self.idTextField.text,
+                 let password = self.passwordTextField.text
+            else { return }
+            self.handleLogin(userId: userId, password: password)
+        }, for: .touchUpInside)
+        
+
     }
 
     private func configureUI() {
@@ -112,7 +123,7 @@ final class LoginViewController: UIViewController {
             idLabel,
             idTextField,
             passwordLabel,
-            passwordLabelTextField,
+            passwordTextField,
             wrongPasswordLabel,
             joinStackView,
             loginButton,
@@ -156,7 +167,7 @@ final class LoginViewController: UIViewController {
             $0.leading.equalTo(idLabel)
         }
 
-        passwordLabelTextField.snp.makeConstraints {
+        passwordTextField.snp.makeConstraints {
             $0.top.equalTo(passwordLabel.snp.bottom).offset(10)
             $0.leading.equalTo(idLabel)
             $0.trailing.equalTo(view.safeAreaLayoutGuide).inset(20)
@@ -164,12 +175,12 @@ final class LoginViewController: UIViewController {
         }
 
         wrongPasswordLabel.snp.makeConstraints {
-            $0.top.equalTo(passwordLabelTextField.snp.bottom).offset(5)
+            $0.top.equalTo(passwordTextField.snp.bottom).offset(5)
             $0.left.equalTo(idLabel)
         }
 
         joinStackView.snp.makeConstraints {
-            $0.top.equalTo(passwordLabelTextField.snp.bottom).offset(50)
+            $0.top.equalTo(passwordTextField.snp.bottom).offset(50)
             $0.centerX.equalToSuperview()
         }
 
@@ -179,4 +190,12 @@ final class LoginViewController: UIViewController {
             $0.height.equalTo(50)
         }
     }
+    
+    
+    func handleLogin(userId: String, password: String) {
+        print("userId : \(userId), password: \(password)")
+        wrongPasswordLabel.isHidden.toggle()
+        
+    }
+    
 }

--- a/PuppyBox/Utils/DummyService.swift
+++ b/PuppyBox/Utils/DummyService.swift
@@ -6,12 +6,9 @@ enum DummyService {
 
     // 최초 실행시 기본계정 생성
     static func createBasicAccount() {
-        let key = "isBasicAccountExist"
-        let defaults = UserDefaults.standard
-
-        if !defaults.bool(forKey: key) { // key값이 false라면
+        if !UserSetting.isBasicAccountExist { // key값이 false라면
             CoreDataManager.shared.createBasicAccount()
-            defaults.set(true, forKey: key)
+            UserSetting.isBasicAccountExist = true
         }
     }
 }

--- a/PuppyBox/Utils/ImagePathService.swift
+++ b/PuppyBox/Utils/ImagePathService.swift
@@ -5,7 +5,7 @@ enum ImagePathService {
     /*
       size는 Models/ImageSize 사용
       호출 예제
-       ImagePathService.makeImagePath(size: ImageSize.w500.rawValue, posterPath: path)
+       ImagePathService.makeImagePath(size: ImageSize.w500, posterPath: path)
      */
 
     static func makeImagePath(size: String, posterPath: String) -> String {


### PR DESCRIPTION
## 📋 PR 타입
- [x] Feat
- [ ] Fix
- [ ] Docs
- [ ] Style
- [x] Refactor
- [ ] Add
- [ ] Chore


## 🔗 관련된 이슈

Closes #4 
Closes #9 


## 🛠️ 작업 내용
로그인 로직 구현 : 로그인 성공시 MovieListViewController 이동 / 데이터 값 저장
다음에 로그인 화면으로 돌아왔을 시 로그인 기록이 있으면 아이디 패스워드 자동 입력

imagePath Service에서 .rawvValue를 안쓰고 바로 접근하게 리팩토링했습니다.

## ✅ 체크리스트
- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?


## 📸 스크린샷

<img width="402" height="720" alt="Simulator Screenshot - iPhone 16 Pro - 2025-07-17 at 14 55 08" src="https://github.com/user-attachments/assets/11c553da-c619-47c0-a43e-03e21d1cd483" />



## 💬 리뷰어에게

