### PR TITLE
#27 chore: 현재 상영작 영화 표지 반대로

### DIFF
--- a/PuppyBox/Scenes/MovieList/MovieListViewController.swift
+++ b/PuppyBox/Scenes/MovieList/MovieListViewController.swift
@@ -144,7 +144,9 @@ extension MovieListViewController: UICollectionViewDataSource {
         let movie: MovieResults?
         switch indexPath.section {
         case 0: movie = viewModel.state.movieChart[indexPath.item]
-        case 1: movie = viewModel.state.nowPlaying[indexPath.item]
+        case 1:
+            let reversedIndex = viewModel.state.nowPlaying.count - 1 - indexPath.item
+            movie = viewModel.state.nowPlaying[reversedIndex]
         case 2: movie = viewModel.state.upcoming[indexPath.item]
         default: movie = nil
         }


### PR DESCRIPTION
## 📋 PR 타입
- [ ] Feat
- [ ] Fix
- [ ] Docs
- [ ] Style
- [ ] Refactor
- [ ] Add
- [x] Chore


## 🔗 관련된 이슈

Closes #26 


## 🛠️ 작업 내용
현재 상영작 section 영화 표지 리스트 반대로띄워 지도록

## ✅ 체크리스트
- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?


## 📸 스크린샷

![Simulator Screen Recording - iPhone 16 Pro - 2025-07-18 at 14 33 42](https://github.com/user-attachments/assets/6a1e90d8-c386-4fba-9ef0-84420e13cc1b)

