### PR TITLE
Fix: #69- 영화 예매 뷰에서 넘겨준 선택된 어른 또는 어린이가 0명이면 좌석 선택 뷰컨트롤러에서 그 부분은 표시하지 않도록 수정

### DIFF
--- a/PuppyBox/Scenes/MovieDetail/SeatSelection/SeatSelectionViewController.swift
+++ b/PuppyBox/Scenes/MovieDetail/SeatSelection/SeatSelectionViewController.swift
@@ -126,7 +126,22 @@ final class SeatSelectionViewController: UIViewController {
             self.applySnapshot(seats: state.displayedSeats)
             self.seatSelectionView.selectedSeatsLabel.text = state.selectedSeats.isEmpty ? "좌석을 선택해주세요." : "\(state.selectedSeats.joined(separator: ", "))"
             self.seatSelectionView.selectedSeatsLabel.textColor = state.selectedSeats.isEmpty ? .systemGray3 : .label
-            self.seatSelectionView.peopleCountLabel.text = "성인 \(state.adultCount) | 어린이 \(state.childCount)"
+            
+            var peopleTexts: [String] = []
+            if state.adultCount > 0 {
+                peopleTexts.append("성인 \(state.adultCount)")
+            }
+            if state.childCount > 0 {
+                peopleTexts.append("어린이 \(state.childCount)")
+            }
+            // 둘 다 0이면
+            if peopleTexts.isEmpty {
+                // 둘 다 0이면 이렇게 표시
+                self.seatSelectionView.peopleCountLabel.text = "선택한 인원이 없습니다. 당신 이걸 어떻게 본 거지?"
+            } else {
+                self.seatSelectionView.peopleCountLabel.text = peopleTexts.joined(separator: " | ")
+            }
+            
             self.seatSelectionView.priceLabel.text = "\(state.totalPrice)원"
             self.seatSelectionView.payButton.isEnabled = state.isPayEnabled
             self.seatSelectionView.payButton.alpha = state.isPayEnabled ? 1.0 : 0.5


### PR DESCRIPTION
## 📋 PR 타입
- [ ] Feat
- [x] Fix
- [ ] Docs
- [ ] Style
- [ ] Refactor
- [ ] Add
- [ ] Chore


## 🔗 관련된 이슈

Closes #69


## 🛠️ 작업 내용
- 영화 예매 뷰에서 넘겨준 선택된 어른 또는 어린이가 0명이면 좌석 선택 뷰컨트롤러에서 그 부분은 표시하지 않도록 수정

## ✅ 체크리스트
- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?


## 📸 스크린샷
![Simulator Screen Recording - iPhone 16 Pro Max - 2025-07-22 at 09 50 34](https://github.com/user-attachments/assets/2ef031f6-311b-4622-a461-abfccb56859a)


## 💬 리뷰어에게