### PR TITLE
Chore: #70- 티켓 뷰 보여지는 부분 수정

### DIFF
--- a/PuppyBox/Scenes/MovieDetail/Ticket/TicketViewController.swift
+++ b/PuppyBox/Scenes/MovieDetail/Ticket/TicketViewController.swift
@@ -69,7 +69,7 @@ final class TicketViewController: UIViewController {
         let posterImageView = UIImageView().then {
             $0.contentMode = .scaleAspectFill
             $0.clipsToBounds = true
-            $0.layer.cornerRadius = 12
+            $0.layer.cornerRadius = 20
             if let path = viewModel.state.movie.posterPath {
                 let urlStr = ImagePathService.makeImagePath(size: .w780, posterPath: path)
                 if let url = URL(string: urlStr) {
@@ -111,14 +111,14 @@ final class TicketViewController: UIViewController {
         collectionView.snp.makeConstraints {
             $0.top.equalTo(infoView.snp.bottom).offset(20)
             $0.leading.trailing.equalToSuperview()
-            $0.height.equalTo(160)
+            $0.height.equalTo(130)
         }
 
         dataSource = UICollectionViewDiffableDataSource<Int, String>(collectionView: collectionView) { collectionView, indexPath, itemIdentifier in
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "SeatInfoCell", for: indexPath) as! SeatInfoCell
             let row = String(itemIdentifier.prefix(1))
             let number = String(itemIdentifier.suffix(itemIdentifier.count - 1))
-            cell.configure(salon: "3관", row: row, num: number)
+            cell.configure(salon: "1관\n(3층)", row: row, num: number)
             return cell
         }
         collectionView.register(SeatInfoCell.self, forCellWithReuseIdentifier: "SeatInfoCell")


### PR DESCRIPTION
…

## 📋 PR 타입
- [ ] Feat
- [ ] Fix
- [ ] Docs
- [ ] Style
- [ ] Refactor
- [ ] Add
- [x] Chore


## 🔗 관련된 이슈

Closes #70 


## 🛠️ 작업 내용
- 포스터이미지의 테두리 곡률 증가
- 포스터이미지 보여지는 높이 축소
- 영화관 3관이 아닌 1관으로 수정

## ✅ 체크리스트
- [x] base 브랜치를 develop으로 설정했나요?
- [x] develop 브랜치를 Pull 받았나요?
- [x] PR의 라벨을 설정했나요?
- [x] assignee를 설정했나요?
- [x] reviewers를 설정했나요?
- [x] 변경 사항에 대한 테스트를 진행했나요?


## 📸 스크린샷
![Simulator Screen Recording - iPhone 16 Pro Max - 2025-07-22 at 09 50 34](https://github.com/user-attachments/assets/a0f669f0-541f-4f29-96a6-bbf74ff61c1c)


## 💬 리뷰어에게
행복하세요